### PR TITLE
Release for v0.1.13

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,42 @@
+# config file for the tagpr in git config format
+# The tagpr generates the initial configuration, which you can rewrite to suit your environment.
+# CONFIGURATIONS:
+#   tagpr.releaseBranch
+#       Generally, it is "main." It is the branch for releases. The tagpr tracks this branch,
+#       creates or updates a pull request as a release candidate, or tags when they are merged.
+#
+#   tagpr.versionFile
+#       Versioning file containing the semantic version needed to be updated at release.
+#       It will be synchronized with the "git tag".
+#       Often this is a meta-information file such as gemspec, setup.cfg, package.json, etc.
+#       Sometimes the source code file, such as version.go or Bar.pm, is used.
+#       If you do not want to use versioning files but only git tags, specify the "-" string here.
+#       You can specify multiple version files by comma separated strings.
+#
+#   tagpr.vPrefix
+#       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
+#       This is only a tagging convention, not how it is described in the version file.
+#
+#   tagpr.changelog (Optional)
+#       Flag whether or not changelog is added or changed during the release.
+#
+#   tagpr.command (Optional)
+#       Command to change files just before release.
+#
+#   tagpr.template (Optional)
+#       Pull request template in go template format
+#
+#   tagpr.release (Optional)
+#       GitHub Release creation behavior after tagging [true, draft, false]
+#       If this value is not set, the release is to be created.
+#
+#   tagpr.majorLabels (Optional)
+#       Label of major update targets. Default is [major]
+#
+#   tagpr.minorLabels (Optional)
+#       Label of minor update targets. Default is [minor]
+#
+[tagpr]
+	vPrefix = true
+	releaseBranch = main
+	versionFile = -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+## [v0.1.13](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.12...v0.1.13) - 2024-07-27
+- Add tests by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/23
+- add tagpr by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/24
+- add octocov.yml by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/26
+
+## [v0.1.12](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.11...v0.1.12) - 2024-07-24
+- Enable to set GitHub base URL by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/20
+
+## [v0.1.11](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.10...v0.1.11) - 2024-07-20
+
+## [v0.1.10](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.9...v0.1.10) - 2024-07-20
+- ActionsでErrorを出力する by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/10
+- create pull request by go module by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/11
+- Bump golang.org/x/crypto from 0.0.0-20190308221718-c2843e01d9a2 to 0.17.0 by @dependabot in https://github.com/kromiii/unleash-checker-ai/pull/12
+
+## [v0.1.9](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.8...v0.1.9) - 2024-07-12
+- ファイル全体を対象とする by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/9
+
+## [v0.1.8](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.7...v0.1.8) - 2024-07-12
+
+## [v0.1.7](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.6...v0.1.7) - 2024-07-07
+
+## [v0.1.6](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.5...v0.1.6) - 2024-07-07
+
+## [v0.1.5](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.4...v0.1.5) - 2024-07-07
+
+## [v0.1.4](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.3...v0.1.4) - 2024-07-07
+- Add GithubAction to Create PR by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/5
+- Modify the summarization report by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/6
+
+## [v0.1.3](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.2...v0.1.3) - 2024-07-03
+
+## [v0.1.2](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.1...v0.1.2) - 2024-07-02
+- Go releaser を使いたい by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/1
+
+## [v0.1.1](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.0...v0.1.1) - 2024-06-30
+
+## [v0.1.0](https://github.com/kromiii/unleash-checker-ai/commits/v0.1.0) - 2024-06-30


### PR DESCRIPTION
This pull request is for the next release as v0.1.13 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.13 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.12" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
## What's Changed
* Add tests by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/23
* add tagpr by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/24
* add octocov.yml by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/26


**Full Changelog**: https://github.com/kromiii/unleash-checker-ai/compare/v0.1.12...v0.1.13