### PR TITLE
Release for v0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.1.16](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.15...v0.1.16) - 2024-08-26
+- correct flag type name by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/38
+
 ## [v0.1.15](https://github.com/kromiii/unleash-checker-ai/compare/v0.1.14...v0.1.15) - 2024-08-04
 - Translation by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/33
 


### PR DESCRIPTION
This pull request is for the next release as v0.1.16 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.16 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.15" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* correct flag type name by @kromiii in https://github.com/kromiii/unleash-checker-ai/pull/38


**Full Changelog**: https://github.com/kromiii/unleash-checker-ai/compare/v0.1.15...v0.1.16